### PR TITLE
Allow for multiple actions on the same dropzone

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,10 +50,7 @@ exports.install = function(Vue, options) {
 				if (dropTo == self.arg) {
 					event.dataTransfer.effectAllowed = 'all';
 					event.dataTransfer.dropEffect = 'copy';
-				} else {
-					event.dataTransfer.effectAllowed = 'none';
-					event.dataTransfer.dropEffect = 'none';
-				}
+				} 
 				return false;
 			};
 			this.dragleave = function(event) {


### PR DESCRIPTION
Removed the code that didn't allow for drop zones other than the ones that had the same tag to drop. This would mean that if a drop zone had a sort and a move function, the first action to be written would be the only one available
